### PR TITLE
Added option to wait for token renewal before resolving request

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ config: {
    
   // (Required) Defines whether access token will be invalidated after this response
   shouldInvalidateAccessToken: (response) => boolean,
+  
+  // When set, response which invalidates token will be resolved after the token has been renewed
+  // in effect, token will be loaded in sync with response, otherwise renew will run async to response
+  shouldWaitForTokenRenewal: boolean,
    
   // (Required) Adds authorization for intercepted requests
   authorizeRequest: (request) => authorizedRequest,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/fetch-token-intercept",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Fetch interceptor for managing refresh token flow.",
   "main": "lib/index.js",
   "files": [

--- a/src/FetchInterceptor.js
+++ b/src/FetchInterceptor.js
@@ -184,6 +184,7 @@ export default class FetchInterceptor {
       response: null,
       shouldIntercept: false,
       shouldInvalidateAccessToken: false,
+      shouldWaitForTokenRenewal: false,
       shouldFetch: true,
       accessToken: null,
       fetchCount: 0,
@@ -293,14 +294,19 @@ export default class FetchInterceptor {
 
   invalidateAccessToken(requestContext) {
     const { shouldIntercept, shouldInvalidateAccessToken } = requestContext;
+    const { shouldWaitForTokenRenewal } = this.config;
 
     if (!shouldIntercept || !shouldInvalidateAccessToken) {
       return requestContext;
     }
 
-    this.accessTokenProvider.renew();
+    if (!shouldWaitForTokenRenewal) {
+      this.accessTokenProvider.renew();
+      return requestContext;
+    }
 
-    return requestContext;
+    return Promise.resolve(this.accessTokenProvider.renew())
+      .then(() => requestContext);
   }
 
   handleResponse(requestContext) {


### PR DESCRIPTION
Added new config flag: shouldWaitForTokenRenewal which causes fetch token library to pause request which caused token invalidation and wait until new token is fetched. Request will be resolved only after new token is successfully fetched.