### PR TITLE
Version bump for republishing corrupted package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/fetch-token-intercept",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Fetch interceptor for managing refresh token flow.",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
Something went wrong with publishing version 0.1.2. I've cleaned lib dir, and prepared a new package, but it has to go on 0.1.3.