### PR TITLE
Added support for importing without configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ config: {
 ```
 
 All required methods return a promise to enable reading of request or response body.
-You should avoid reading the body directly on provided requests and responses and instead clone 
-them first. The library does not clone objects to avoid unnecessary overhead in cases where 
+You should avoid reading the body directly on provided requests and responses and instead **clone 
+them first.** The library does not clone objects to avoid unnecessary overhead in cases where 
 reading a body is not required to provide data.
 
 To configure the interceptor you should import and call `configure` function. And when you obtain
@@ -116,6 +116,10 @@ to stop fetch interception.
  `clear()`
  
  Clears all tokens from interceptor.
+ 
+ `unload()`
+  
+  Completely unloads the library and restores initial state.
  
  `isResponseUnauthorized(response)`
  

--- a/package.json
+++ b/package.json
@@ -57,5 +57,7 @@
     "nock": "^8.0.0",
     "sinon": "^1.17.4"
   },
-  "dependencies": {}
+  "dependencies": {
+    "lodash": "^4.17.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/fetch-token-intercept",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Fetch interceptor for managing refresh token flow.",
   "main": "lib/index.js",
   "files": [

--- a/src/AccessTokenProvider.js
+++ b/src/AccessTokenProvider.js
@@ -1,5 +1,3 @@
-import { ERROR_INVALID_CONFIG } from './const';
-
 /**
  * Provides a way for renewing access token with correct refresh token. It will automatically
  * dispatch a call to server with request provided via config. It also ensures that
@@ -7,7 +5,7 @@ import { ERROR_INVALID_CONFIG } from './const';
  * a renewed version of access token at the moment. All subsequent requests will be chained
  * to renewing fetch promise and resolved once the response is received.
  */
-export default class AccessTokenProvider {
+class AccessTokenProvider {
   constructor(fetch, config) {
     this.fetch = fetch;
 
@@ -29,7 +27,6 @@ export default class AccessTokenProvider {
     this.handleFetchAccessTokenResponse = this.handleFetchAccessTokenResponse.bind(this);
     this.handleAccessToken = this.handleAccessToken.bind(this);
     this.handleError = this.handleError.bind(this);
-    this.isConfigValid = this.isConfigValid.bind(this);
   }
 
   /**
@@ -37,12 +34,6 @@ export default class AccessTokenProvider {
    */
   configure(config) {
     this.config = { ...this.config, ...config };
-
-    if (!this.isConfigValid(this.config)) {
-      throw new Error(ERROR_INVALID_CONFIG);
-    }
-
-    this.config = config;
   }
 
   /**
@@ -135,10 +126,6 @@ export default class AccessTokenProvider {
       .then(token => this.handleAccessToken(token, resolve))
       .catch(error => this.handleError(error, reject));
   }
-
-  isConfigValid() {
-    return this.config.isResponseUnauthorized &&
-      this.config.createAccessTokenRequest &&
-      this.config.parseAccessToken;
-  }
 }
+
+export default AccessTokenProvider;

--- a/src/AccessTokenProvider.js
+++ b/src/AccessTokenProvider.js
@@ -1,3 +1,5 @@
+import { ERROR_INVALID_CONFIG } from './const';
+
 /**
  * Provides a way for renewing access token with correct refresh token. It will automatically
  * dispatch a call to server with request provided via config. It also ensures that
@@ -27,6 +29,20 @@ export default class AccessTokenProvider {
     this.handleFetchAccessTokenResponse = this.handleFetchAccessTokenResponse.bind(this);
     this.handleAccessToken = this.handleAccessToken.bind(this);
     this.handleError = this.handleError.bind(this);
+    this.isConfigValid = this.isConfigValid.bind(this);
+  }
+
+  /**
+   * Configures access token provider
+   */
+  configure(config) {
+    this.config = { ...this.config, ...config };
+
+    if (!this.isConfigValid(this.config)) {
+      throw new Error(ERROR_INVALID_CONFIG);
+    }
+
+    this.config = config;
   }
 
   /**
@@ -118,5 +134,11 @@ export default class AccessTokenProvider {
       .then(this.handleFetchAccessTokenResponse)
       .then(token => this.handleAccessToken(token, resolve))
       .catch(error => this.handleError(error, reject));
+  }
+
+  isConfigValid() {
+    return this.config.isResponseUnauthorized &&
+      this.config.createAccessTokenRequest &&
+      this.config.parseAccessToken;
   }
 }

--- a/src/FetchInterceptor.js
+++ b/src/FetchInterceptor.js
@@ -14,11 +14,12 @@ export default class FetchInterceptor {
   constructor(fetch) {
     // stores reference to vanilla fetch method
     this.fetch = fetch;
+    this.accessTokenProvider = new AccessTokenProvider(this.fetch);
 
     this.config = {
       fetchRetryCount: 1,
       createAccessTokenRequest: null,
-      shouldIntercept: () => true,
+      shouldIntercept: () => false,
       shouldInvalidateAccessToken: () => false,
       isResponseUnauthorized: http.isResponseUnauthorized,
       parseAccessToken: null,
@@ -87,7 +88,7 @@ export default class FetchInterceptor {
       throw new Error(ERROR_INVALID_CONFIG);
     }
 
-    this.accessTokenProvider = new AccessTokenProvider(this.fetch, this.config);
+    this.accessTokenProvider.configure(this.config);
   }
 
   /**
@@ -125,9 +126,7 @@ export default class FetchInterceptor {
 
   isConfigValid() {
     return this.config.shouldIntercept &&
-      this.config.authorizeRequest &&
-      this.config.createAccessTokenRequest &&
-      this.config.parseAccessToken;
+      this.config.authorizeRequest;
   }
 
   resolveIntercept(resolve, reject, ...args) {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ import { isResponseUnauthorized } from './services/http';
 import FetchInterceptor from './FetchInterceptor';
 
 let interceptor = null;
-let nativeFetch = null;
 let environment = null;
 
 export function attach(env) {
@@ -16,8 +15,6 @@ export function attach(env) {
   if (interceptor) {
     throw Error('You should attach only once.');
   }
-
-  nativeFetch = env.fetch;
 
   // for now add default interceptor
   interceptor = new FetchInterceptor(env.fetch);
@@ -40,7 +37,8 @@ function initialize() {
 
 /**
  * Initializes and configures interceptor
- * @param config
+ * @param config Configuration object
+ * @see FetchInterceptor#configure
  */
 export function configure(config) {
   if (!interceptor) {
@@ -53,6 +51,7 @@ export function configure(config) {
 /**
  * Initializes tokens which will be used by interceptor
  * @param args
+ * @see FetchInterceptor#authorize
  */
 export function authorize(...args) {
   interceptor.authorize(...args);
@@ -86,12 +85,7 @@ export function isActive() {
  */
 export function unload() {
   if (interceptor) {
-    interceptor.clear();
-    interceptor = null;
-  }
-
-  if (environment) {
-    environment.fetch = nativeFetch;
+    interceptor.unload();
   }
 }
 

--- a/src/services/RetryCountExceededException.js
+++ b/src/services/RetryCountExceededException.js
@@ -5,7 +5,7 @@ export default class RetryCountExceededException extends Error {
     this.requestContext = requestContext;
 
     // Use V8's native method if available, otherwise fallback
-    if ("captureStackTrace" in Error) {
+    if ('captureStackTrace' in Error) {
       Error.captureStackTrace(this, RetryCountExceededException);
     } else {
       this.stack = (new Error()).stack;

--- a/src/services/TokenExpiredException.js
+++ b/src/services/TokenExpiredException.js
@@ -5,7 +5,7 @@ export default class TokenExpiredException extends Error {
     this.name = this.constructor.name;
 
     // Use V8's native method if available, otherwise fallback
-    if ("captureStackTrace" in Error) {
+    if ('captureStackTrace' in Error) {
       Error.captureStackTrace(this, TokenExpiredException);
     } else {
       this.stack = (new Error()).stack;

--- a/src/services/environment.js
+++ b/src/services/environment.js
@@ -14,3 +14,20 @@ export function isWeb() {
 export function isWorker() {
   return typeof importScripts === 'function';
 }
+
+export function resolveEnvironment() {
+  if (isReactNative()) {
+    return global;
+  }
+  if (isWorker()) {
+    return self;
+  }
+  if (isWeb()) {
+    return window;
+  }
+  if (isNode()) {
+    return global;
+  }
+
+  return null;
+}

--- a/src/services/http.js
+++ b/src/services/http.js
@@ -1,6 +1,12 @@
 export const STATUS_UNAUTHORIZED = 401;
 export const STATUS_OK = 200;
 
+/**
+ * Checks if response status matches the provided status
+ * @param response Response object
+ * @param status Query status
+ * @returns {boolean} Value indicating whether response status matches query status
+ */
 function isResponseStatus(response, status) {
   if (!response) {
     return false;

--- a/test/FetchInterceptor.spec.js
+++ b/test/FetchInterceptor.spec.js
@@ -82,6 +82,35 @@ describe('fetch-intercept', function () {
     });
   });
 
+  describe('unload', function () {
+    beforeEach(done => {
+      server.start(done);
+    });
+
+    afterEach(done => {
+      server.stop(done);
+    });
+
+    it('should clear authorization tokens and stop intercepting requests', done => {
+      fetchInterceptor.configure(configuration());
+      fetchInterceptor.authorize('refreshToken', 'accessToken');
+      fetchInterceptor.unload();
+
+      // assert that authorization has been cleared
+      const { refreshToken, accessToken } = fetchInterceptor.getAuthorization();
+      expect(refreshToken).to.be.null;
+      expect(accessToken).to.be.null;
+
+      // assert that fetch now works ok without interceptor
+      fetch('http://localhost:5000/200').then((response) => {
+        expect(response.status).to.be.equal(200);
+        done();
+      }).catch(err => {
+        done(err);
+      });
+    });
+  });
+
   describe('should not change default fetch behaviour', () => {
     describe('server is running', () => {
       beforeEach(done => {

--- a/test/FetchInterceptor.spec.js
+++ b/test/FetchInterceptor.spec.js
@@ -1,32 +1,11 @@
 import 'fetch-everywhere';
-import {expect} from 'chai';
+import { expect } from 'chai';
 import * as server from './helpers/server';
-import {delayPromise} from './helpers/promiseHelpers';
-import {formatBearer} from './helpers/tokenFormatter';
-import {ERROR_INVALID_CONFIG} from '../src/const';
+import { delayPromise } from './helpers/promiseHelpers';
+import configuration from './helpers/defaultConfigFactory';
+import { ERROR_INVALID_CONFIG } from '../src/const';
 import * as fetchInterceptor from '../src/index';
 import sinon from 'sinon';
-
-const configuration = config => ({
-  fetchRetryCount: 1,
-  createAccessTokenRequest: refreshToken =>
-    new Request('http://localhost:5000/token', {
-      headers: {
-        authorization: `Bearer ${refreshToken}`
-      }
-    }),
-  shouldIntercept: request => request.url.toString() !== 'http://localhost:5000/token',
-  parseAccessToken: response =>
-    response.json().then(jsonData => jsonData ? jsonData.accessToken : null),
-  authorizeRequest: (request, token) => {
-    request.headers.set('authorization', formatBearer(token));
-    return request;
-  },
-  onAccessTokenChange: null,
-  onResponse: null,
-  isResponseUnauthorized: response => response.status === 401,
-  ...config,
-});
 
 describe('fetch-intercept', function () {
   describe('configure', () => {
@@ -69,6 +48,15 @@ describe('fetch-intercept', function () {
 
       expect(() => fetchInterceptor.configure(config)).to.throw(Error, ERROR_INVALID_CONFIG);
     });
+
+    it('should gracefully handle requests when not configured', done => {
+      fetch('http://localhost:5000/200').then((response) => {
+        expect(response.status).to.be.equal(200);
+        done();
+      }).catch(err => {
+        done(err);
+      })
+    })
   });
 
   describe('authorize', function() {

--- a/test/helpers/defaultConfigFactory.js
+++ b/test/helpers/defaultConfigFactory.js
@@ -1,0 +1,24 @@
+import { formatBearer } from './tokenFormatter';
+
+export default function(config) {
+  return {
+    fetchRetryCount: 1,
+    createAccessTokenRequest: refreshToken =>
+      new Request('http://localhost:5000/token', {
+        headers: {
+          authorization: `Bearer ${refreshToken}`
+        }
+      }),
+    shouldIntercept: request => request.url.toString() !== 'http://localhost:5000/token',
+    parseAccessToken: response =>
+      response.json().then(jsonData => jsonData ? jsonData.accessToken : null),
+    authorizeRequest: (request, token) => {
+      request.headers.set('authorization', formatBearer(token));
+      return request;
+    },
+    onAccessTokenChange: null,
+    onResponse: null,
+    isResponseUnauthorized: response => response.status === 401,
+    ...config,
+  };
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -53,13 +53,4 @@ describe('index', function() {
       expect(accessToken).to.equal('access-token');
     });
   });
-
-  describe('unload', function() {
-    it('should unload and detach interceptor', function (){
-      fetchInterceptor.configure(config());
-      fetchInterceptor.unload();
-
-      expect(fetchInterceptor.isActive()).to.be.false;
-    });
-  });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,65 @@
+import 'fetch-everywhere';
+import { expect } from 'chai';
+import * as server from './helpers/server';
+import config from './helpers/defaultConfigFactory';
+import * as fetchInterceptor from '../src';
+
+describe('index', function() {
+  beforeEach(done => {
+    fetchInterceptor.unload();
+    server.start(done);
+  });
+
+  afterEach(done => {
+    server.stop(done);
+  });
+
+  describe('configure', function() {
+    it('should initialize interceptor', function (){
+      fetchInterceptor.configure(config());
+
+      expect(fetchInterceptor.isActive()).to.not.be.empty;
+    });
+  });
+
+  describe('getAuthorization', function() {
+    it('should return empty authorization', function (){
+      fetchInterceptor.configure(config());
+
+      const { refreshToken, accessToken } = fetchInterceptor.getAuthorization();
+
+      expect(refreshToken).to.be.null;
+      expect(accessToken).to.be.null;
+    });
+
+    it('should return empty authorization after clearing', function (){
+      fetchInterceptor.configure(config());
+      fetchInterceptor.authorize('refresh-token', 'access-token');
+      fetchInterceptor.clear();
+
+      const { refreshToken, accessToken } = fetchInterceptor.getAuthorization();
+
+      expect(refreshToken).to.be.null;
+      expect(accessToken).to.be.null;
+    });
+
+    it('should return authorization keys when authorized', function (){
+      fetchInterceptor.configure(config());
+      fetchInterceptor.authorize('refresh-token', 'access-token');
+
+      const { refreshToken, accessToken } = fetchInterceptor.getAuthorization();
+
+      expect(refreshToken).to.equal('refresh-token');
+      expect(accessToken).to.equal('access-token');
+    });
+  });
+
+  describe('unload', function() {
+    it('should unload and detach interceptor', function (){
+      fetchInterceptor.configure(config());
+      fetchInterceptor.unload();
+
+      expect(fetchInterceptor.isActive()).to.be.false;
+    });
+  });
+});

--- a/test/services/http.spec.js
+++ b/test/services/http.spec.js
@@ -1,0 +1,36 @@
+import 'fetch-everywhere';
+import { expect } from 'chai';
+import * as http from '../../src/services/http';
+
+describe('services', () => {
+  describe('http', () => {
+    describe('isResponseOk', () => {
+      it('should return false on empty response', () => {
+        expect(http.isResponseOk(null)).to.be.false;
+      });
+
+      it('should return false on non-OK response', () => {
+        expect(http.isResponseOk(new Response({}, { status: 401 }))).to.be.false;
+      });
+
+      it('should return true on OK response', () => {
+        expect(http.isResponseOk(new Response({}, { status: 200 }))).to.be.true;
+      });
+    });
+
+    describe('isResponseUnauthorized', () => {
+      it('should return false on empty response', () => {
+        expect(http.isResponseUnauthorized(null)).to.be.false;
+      });
+
+      it('should return false on authorized response', () => {
+        expect(http.isResponseUnauthorized(new Response({}, { status: 200 }))).to.be.false;
+      });
+
+      it('should return true on unauthorized response', () => {
+        expect(http.isResponseUnauthorized(new Response({}, { status: 401 }))).to.be.true;
+      });
+    });
+  });
+});
+


### PR DESCRIPTION
- library will gracefully handle requests if configure was never called
- implemented new tests
- added root level tests
Defaulted shouldIntercept to false
Added unload method to public api - restores fetch to it's original state
Updated help file
Fixed linter errors
Version bump 0.3.0